### PR TITLE
Fix OBJECTIFY_RESULT in znlog()

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -1967,7 +1967,7 @@ znlog(IN SV* sva, IN SV* svg, IN SV* svp)
       case 4:
       default:_vcallsub_with_gmpobj(0.36,"powmod"); break;
     }
-    OBJECTIFY_RESULT(svp, ST(items-1));
+    OBJECTIFY_RESULT(svp, ST(0));
     return; /* skip implicit PUTBACK */
 
 void


### PR DESCRIPTION
This fixes the objectification of the result for some big-int libraries in `znlog()`.

Test code:
```perl
use 5.014;
use ntheory qw(znlog);

my @classes = qw(Math::BigInt Math::GMP Math::GMPz Math::BigRat Math::AnyNum Math::BigFloat Math::Pari Math::GMPq);
eval "use $_" for @classes;

my $x = "232752345212475230211680";
my $y = "23847293847923847239847098123812075234";
my $z = "804842536444911030681947";

foreach my $class (@classes) {
    my $r = eval { znlog($class->new($x), $class->new($y), $class->new($z)) };
    say "$class --> ", $r // $@;
}
```