### PR TITLE
Fix unsigned integer division in powerfree_count

### DIFF
--- a/powerfree.c
+++ b/powerfree.c
@@ -124,7 +124,7 @@ UV powerfree_count(UV n, uint32_t k)
     signed char* mu = range_moebius(0, nk);
     for (i = 2; i <= nk; i++)
       if (mu[i] != 0)
-        count += mu[i] * n/ipow(i,k);
+        count += mu[i] * (n/ipow(i,k));
     Safefree(mu);
   }
   return count;


### PR DESCRIPTION
Fix unsigned integer division in powerfree_count

Issue introduced in https://github.com/danaj/Math-Prime-Util/commit/c66fd6e0123de3b4d1af124a6fc23ab94de40e9c