### PR TITLE
Switch inline assembly command to __asm__

### DIFF
--- a/montmath.h
+++ b/montmath.h
@@ -38,7 +38,7 @@ static INLINE uint64_t mont_inverse(const uint64_t n) {
 
 /* MULREDC asm from Ben Buhrow */
 static INLINE uint64_t _mulredc63(uint64_t a, uint64_t b, uint64_t n, uint64_t npi) {
-    asm("mulq %2 \n\t"
+    __asm__ ("mulq %2 \n\t"
         "movq %%rax, %%r10 \n\t"
         "movq %%rdx, %%r11 \n\t"
         "mulq %3 \n\t"
@@ -55,7 +55,7 @@ static INLINE uint64_t _mulredc63(uint64_t a, uint64_t b, uint64_t n, uint64_t n
   return a;
 }
 static INLINE uint64_t _mulredc64(uint64_t a, uint64_t b, uint64_t n, uint64_t npi) {
-    asm("mulq %1 \n\t"
+    __asm__ ("mulq %1 \n\t"
         "movq %%rax, %%r10 \n\t"
         "movq %%rdx, %%r11 \n\t"
         "movq $0, %%r12 \n\t"

--- a/mulmod.h
+++ b/mulmod.h
@@ -23,7 +23,7 @@
   /* Beware: if (a*b)/c > 2^64, there will be an FP exception */
   static INLINE UV _mulmod(UV a, UV b, UV n) {
     UV d, dummy;                    /* d will get a*b mod c */
-    asm ("mulq %3\n\t"              /* mul a*b -> rdx:rax */
+    __asm__ ("mulq %3\n\t"              /* mul a*b -> rdx:rax */
          "divq %4\n\t"              /* (a*b)/c -> quot in rax remainder in rdx */
          :"=a"(dummy), "=&d"(d)     /* output */
          :"a"(a), "r"(b), "r"(n)    /* input */
@@ -43,7 +43,7 @@
   static INLINE UV _addmod(UV a, UV b, UV n) {
     UV t = a-n;
     a += b;
-    asm ("add %2, %1\n\t"    /* t := t + b */
+    __asm__ ("add %2, %1\n\t"    /* t := t + b */
          "cmovc %1, %0\n\t"  /* if (carry) a := t */
          :"+r" (a), "+&r" (t)
          :"r" (b)


### PR DESCRIPTION
Switch the inline assembly invocation from asm to __asm__ for broader compatibility : Fixes #79 

The asm implementation is not recognized in some configurations. 
Observed failure with Perl 5.40 and MinGW gcc compiler. 